### PR TITLE
Add guard and prefix option to the config

### DIFF
--- a/config/airlock.php
+++ b/config/airlock.php
@@ -29,5 +29,7 @@ return [
     */
 
     'expiration' => null,
-
+    'guard' => 'api',
+    'prefix' => 'api',
+    
 ];


### PR DESCRIPTION
To make the guard configurable and not hard coded in ``` Laravel\Airlock\Guard ``` I changed:
``` php
$this->auth->guard(config('airlock.guard'))
```
In ``` __invoke(Request $request); supportsTokens(); ``` methods